### PR TITLE
feat(admin): enhance LayerGroup management with color customization

### DIFF
--- a/applications/projects/admin.py
+++ b/applications/projects/admin.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 from django import forms
 from django.db import models
 from django.utils.html import format_html
-from .models import Project, LayerGroup, Layer, DefaultLayer
+from .models import Project, LayerGroup, Layer
 
 
 @admin.register(Project)
@@ -219,23 +219,3 @@ class LayerAdmin(admin.ModelAdmin):
         return filter_groups_by_project(request)
 
 
-@admin.register(DefaultLayer)
-class DefaultLayerAdmin(admin.ModelAdmin):
-    """
-    Admin interface for DefaultLayer model
-    """
-    list_display = ['proyecto', 'layer', 'visible_inicial']
-    list_filter = ['proyecto', 'visible_inicial']
-    search_fields = ['proyecto__nombre_corto', 'layer__nombre_display']
-    list_editable = ['visible_inicial']
-
-    fieldsets = (
-        ('Configuration', {
-            'fields': ('proyecto', 'layer', 'visible_inicial')
-        }),
-        ('Timestamps', {
-            'fields': ('created_at',),
-            'classes': ('collapse',)
-        }),
-    )
-    readonly_fields = ['created_at']

--- a/applications/projects/admin.py
+++ b/applications/projects/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django import forms
 from django.db import models
+from django.utils.html import format_html
 from .models import Project, LayerGroup, Layer, DefaultLayer
 
 
@@ -34,22 +35,48 @@ class ProjectAdmin(admin.ModelAdmin):
     )
 
 
+class LayerGroupAdminForm(forms.ModelForm):
+    """
+    Custom form with color picker widget
+    """
+    class Meta:
+        model = LayerGroup
+        fields = '__all__'
+        widgets = {
+            'color': forms.TextInput(attrs={
+                'type': 'color',
+                'style': 'width: 100px; height: 40px; cursor: pointer;'
+            })
+        }
+
+
 @admin.register(LayerGroup)
 class LayerGroupAdmin(admin.ModelAdmin):
     """
     Admin interface for LayerGroup model
     """
-    list_display = ['nombre', 'proyecto', 'parent_group', 'orden', 'fold_state']
+    form = LayerGroupAdminForm
+    list_display = ['nombre', 'proyecto', 'parent_group', 'orden', 'fold_state', 'color_preview']
     list_filter = ['proyecto', 'fold_state', 'parent_group']
     search_fields = ['nombre', 'proyecto__nombre_corto']
     list_editable = ['orden']
+
+    def color_preview(self, obj):
+        """
+        Display color preview in list view
+        """
+        return format_html(
+            '<div style="width: 30px; height: 30px; background-color: {}; border: 1px solid #ccc; border-radius: 3px;"></div>',
+            obj.color
+        )
+    color_preview.short_description = 'Color'
 
     fieldsets = (
         ('Basic Information', {
             'fields': ('proyecto', 'nombre', 'parent_group')
         }),
         ('Display Configuration', {
-            'fields': ('orden', 'fold_state')
+            'fields': ('orden', 'fold_state', 'color')
         }),
         ('Timestamps', {
             'fields': ('created_at', 'updated_at'),
@@ -77,7 +104,7 @@ class LayerAdminForm(forms.ModelForm):
     class Meta:
         model = Layer
         fields = '__all__'
-        
+
     def full_clean(self):
         if 'grupo' in self.data and self.data['grupo']:
             try:
@@ -114,7 +141,7 @@ class LayerAdminForm(forms.ModelForm):
             return LayerGroup.objects.get(pk=grupo_id)
         except (ValueError, LayerGroup.DoesNotExist):
             raise forms.ValidationError('Grupo no válido.')
-    
+
     def clean(self):
         cleaned_data = super().clean()
         proyecto = cleaned_data.get('proyecto')

--- a/applications/projects/management/commands/populate_projects.py
+++ b/applications/projects/management/commands/populate_projects.py
@@ -1,5 +1,5 @@
 from django.core.management.base import BaseCommand
-from applications.projects.models import Project, LayerGroup, Layer, DefaultLayer
+from applications.projects.models import Project, LayerGroup, Layer
 
 
 class Command(BaseCommand):

--- a/applications/projects/migrations/0002_layergroup_color.py
+++ b/applications/projects/migrations/0002_layergroup_color.py
@@ -1,0 +1,30 @@
+# Generated migration to add color field to LayerGroup
+
+import django.core.validators
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('projects', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='layergroup',
+            name='color',
+            field=models.CharField(
+                default='#e3e3e3',
+                help_text='Hexadecimal color code for the layer group (e.g., #FF5733)',
+                max_length=7,
+                validators=[
+                    django.core.validators.RegexValidator(
+                        code='invalid_color',
+                        message='Enter a valid hexadecimal color code (e.g., #FF5733 or #F57)',
+                        regex='^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$'
+                    )
+                ]
+            ),
+        ),
+    ]

--- a/applications/projects/models.py
+++ b/applications/projects/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.contrib.gis.db import models as gis_models
+from django.core.validators import RegexValidator
 
 
 class Project(models.Model):
@@ -15,7 +16,7 @@ class Project(models.Model):
     coordenada_central_y = models.FloatField(help_text="Center Y coordinate")
     panel_visible = models.BooleanField(default=True, help_text="Panel visibility on startup")
     base_map_visible = models.CharField(
-        max_length=50, 
+        max_length=50,
         default='streetmap',
         choices=[
             ('streetmap', 'Street Map'),
@@ -54,12 +55,24 @@ class LayerGroup(models.Model):
         help_text="Initial fold state"
     )
     parent_group = models.ForeignKey(
-        'self', 
-        on_delete=models.CASCADE, 
-        null=True, 
-        blank=True, 
+        'self',
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
         related_name='subgroups',
         help_text="Parent group for subgroups"
+    )
+    color = models.CharField(
+        max_length=7,
+        default='#e3e3e3',
+        validators=[
+            RegexValidator(
+                regex=r'^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$',
+                message='Enter a valid hexadecimal color code (e.g., #FF5733 or #F57)',
+                code='invalid_color'
+            )
+        ],
+        help_text='Hexadecimal color code for the layer group (e.g., #FF5733)'
     )
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
@@ -84,9 +97,9 @@ class Layer(models.Model):
     store_geoserver = models.CharField(max_length=200, help_text="GeoServer store name")
     estado_inicial = models.BooleanField(default=False, help_text="Initial visibility state")
     metadata_id = models.CharField(
-        max_length=500, 
-        blank=True, 
-        null=True, 
+        max_length=500,
+        blank=True,
+        null=True,
         help_text="Metadata ID or external URL"
     )
     orden = models.IntegerField(default=0, help_text="Display order within group")

--- a/applications/projects/models.py
+++ b/applications/projects/models.py
@@ -116,20 +116,3 @@ class Layer(models.Model):
         return f"{self.grupo.proyecto.nombre_corto} - {self.nombre_display}"
 
 
-class DefaultLayer(models.Model):
-    """
-    Model for default layers that should be loaded when entering a project
-    """
-    proyecto = models.ForeignKey(Project, on_delete=models.CASCADE, related_name='default_layers')
-    layer = models.ForeignKey(Layer, on_delete=models.CASCADE)
-    visible_inicial = models.BooleanField(default=True, help_text="Initial visibility")
-    created_at = models.DateTimeField(auto_now_add=True)
-
-    class Meta:
-        db_table = 'default_layers'
-        verbose_name = 'Default Layer'
-        verbose_name_plural = 'Default Layers'
-        unique_together = ['proyecto', 'layer']
-
-    def __str__(self):
-        return f"{self.proyecto.nombre_corto} - {self.layer.nombre_display}"

--- a/applications/projects/serializers.py
+++ b/applications/projects/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+import re
 from .models import Project, LayerGroup, Layer, DefaultLayer
 
 
@@ -25,8 +26,19 @@ class LayerGroupSerializer(serializers.ModelSerializer):
         model = LayerGroup
         fields = [
             'id', 'nombre', 'orden', 'fold_state', 'parent_group',
-            'layers', 'subgroups'
+            'color', 'layers', 'subgroups'
         ]
+
+    def validate_color(self, value):
+        """
+        Validate hexadecimal color format
+        """
+        pattern = r'^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$'
+        if not re.match(pattern, value):
+            raise serializers.ValidationError(
+                'Invalid color format. Use hexadecimal format (e.g., #FF5733 or #F57)'
+            )
+        return value.upper()  # Normalize to uppercase
 
     def get_subgroups(self, obj):
         """

--- a/applications/projects/serializers.py
+++ b/applications/projects/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 import re
-from .models import Project, LayerGroup, Layer, DefaultLayer
+from .models import Project, LayerGroup, Layer
 
 
 class LayerSerializer(serializers.ModelSerializer):
@@ -48,17 +48,6 @@ class LayerGroupSerializer(serializers.ModelSerializer):
         return LayerGroupSerializer(subgroups, many=True).data
 
 
-class DefaultLayerSerializer(serializers.ModelSerializer):
-    """
-    Serializer for DefaultLayer model
-    """
-    layer = LayerSerializer(read_only=True)
-
-    class Meta:
-        model = DefaultLayer
-        fields = ['id', 'layer', 'visible_inicial']
-
-
 class ProjectSerializer(serializers.ModelSerializer):
     """
     Serializer for Project model
@@ -77,13 +66,10 @@ class ProjectDetailSerializer(serializers.ModelSerializer):
     Detailed serializer for Project model with related data
     """
     layer_groups = LayerGroupSerializer(many=True, read_only=True)
-    default_layers = DefaultLayerSerializer(many=True, read_only=True)
-
     class Meta:
         model = Project
         fields = [
             'id', 'nombre_corto', 'nombre', 'logo_pequeno_url', 'logo_completo_url',
             'nivel_zoom', 'coordenada_central_x', 'coordenada_central_y',
-            'panel_visible', 'base_map_visible', 'layer_groups', 'default_layers',
-            'created_at', 'updated_at'
+            'panel_visible', 'base_map_visible', 'layer_groups', 'created_at', 'updated_at'
         ]

--- a/applications/projects/tests/__init__.py
+++ b/applications/projects/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests package for projects application

--- a/applications/projects/tests/test_api.py
+++ b/applications/projects/tests/test_api.py
@@ -1,0 +1,238 @@
+"""
+Integration tests for LayerGroup API with color field
+"""
+from rest_framework.test import APITestCase
+from rest_framework import status
+from django.contrib.auth.models import User
+from applications.projects.models import Project, LayerGroup
+
+
+class LayerGroupColorAPITests(APITestCase):
+    """Test cases for LayerGroup API color functionality"""
+
+    def setUp(self):
+        """Set up test data"""
+        self.user = User.objects.create_user(
+            username='testuser',
+            password='testpass123'
+        )
+        self.project = Project.objects.create(
+            nombre_corto='test',
+            nombre='Test Project',
+            coordenada_central_x=-74.0,
+            coordenada_central_y=4.0
+        )
+        self.group = LayerGroup.objects.create(
+            proyecto=self.project,
+            nombre='Test Group',
+            color='#FF5733'
+        )
+
+    def test_get_layer_group_includes_color(self):
+        """Test GET returns color field"""
+        url = f'/api/layer-groups/{self.group.id}/'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('color', response.data)
+        self.assertEqual(response.data['color'], '#FF5733')
+
+    def test_list_layer_groups_includes_color(self):
+        """Test LIST returns color field for all groups"""
+        url = '/api/layer-groups/'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertGreater(len(response.data), 0)
+        self.assertIn('color', response.data[0])
+
+    def test_create_layer_group_with_color(self):
+        """Test POST creates group with color"""
+        self.client.force_authenticate(user=self.user)
+        url = '/api/layer-groups/'
+        data = {
+            'proyecto': self.project.id,
+            'nombre': 'New Group',
+            'color': '#00FF00',
+            'orden': 1,
+            'fold_state': 'close'
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['color'], '#00FF00')
+
+        # Verify in database
+        group = LayerGroup.objects.get(id=response.data['id'])
+        self.assertEqual(group.color, '#00FF00')
+
+    def test_create_layer_group_with_3_digit_color(self):
+        """Test POST creates group with 3-digit color"""
+        self.client.force_authenticate(user=self.user)
+        url = '/api/layer-groups/'
+        data = {
+            'proyecto': self.project.id,
+            'nombre': 'New Group',
+            'color': '#F57',
+            'orden': 1,
+            'fold_state': 'close'
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['color'], '#F57')
+
+    def test_create_layer_group_without_color_uses_default(self):
+        """Test POST without color uses default"""
+        self.client.force_authenticate(user=self.user)
+        url = '/api/layer-groups/'
+        data = {
+            'proyecto': self.project.id,
+            'nombre': 'New Group',
+            'orden': 1,
+            'fold_state': 'close'
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['color'], '#e3e3e3')
+
+    def test_update_layer_group_color(self):
+        """Test PUT updates color"""
+        self.client.force_authenticate(user=self.user)
+        url = f'/api/layer-groups/{self.group.id}/'
+        data = {
+            'proyecto': self.project.id,
+            'nombre': 'Test Group',
+            'color': '#0000FF',
+            'orden': 0,
+            'fold_state': 'close'
+        }
+        response = self.client.put(url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['color'], '#0000FF')
+
+        # Verify in database
+        self.group.refresh_from_db()
+        self.assertEqual(self.group.color, '#0000FF')
+
+    def test_partial_update_layer_group_color(self):
+        """Test PATCH updates only color"""
+        self.client.force_authenticate(user=self.user)
+        url = f'/api/layer-groups/{self.group.id}/'
+        data = {'color': '#ABCDEF'}
+        response = self.client.patch(url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['color'], '#ABCDEF')
+
+        # Verify other fields unchanged
+        self.group.refresh_from_db()
+        self.assertEqual(self.group.nombre, 'Test Group')
+        self.assertEqual(self.group.color, '#ABCDEF')
+
+    def test_invalid_color_returns_error(self):
+        """Test invalid color returns 400"""
+        self.client.force_authenticate(user=self.user)
+        url = '/api/layer-groups/'
+        data = {
+            'proyecto': self.project.id,
+            'nombre': 'New Group',
+            'color': 'invalid',
+            'orden': 1,
+            'fold_state': 'close'
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('color', response.data)
+
+    def test_color_without_hash_returns_error(self):
+        """Test color without # returns 400"""
+        self.client.force_authenticate(user=self.user)
+        url = '/api/layer-groups/'
+        data = {
+            'proyecto': self.project.id,
+            'nombre': 'New Group',
+            'color': 'FF5733',
+            'orden': 1,
+            'fold_state': 'close'
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('color', response.data)
+
+    def test_invalid_hex_characters_returns_error(self):
+        """Test invalid hex characters return 400"""
+        self.client.force_authenticate(user=self.user)
+        url = '/api/layer-groups/'
+        data = {
+            'proyecto': self.project.id,
+            'nombre': 'New Group',
+            'color': '#GG5733',
+            'orden': 1,
+            'fold_state': 'close'
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('color', response.data)
+
+    def test_wrong_length_color_returns_error(self):
+        """Test wrong length color returns 400"""
+        self.client.force_authenticate(user=self.user)
+        url = '/api/layer-groups/'
+        data = {
+            'proyecto': self.project.id,
+            'nombre': 'New Group',
+            'color': '#FF57',  # 4 digits
+            'orden': 1,
+            'fold_state': 'close'
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('color', response.data)
+
+    def test_color_normalization_to_uppercase(self):
+        """Test color is normalized to uppercase"""
+        self.client.force_authenticate(user=self.user)
+        url = '/api/layer-groups/'
+        data = {
+            'proyecto': self.project.id,
+            'nombre': 'New Group',
+            'color': '#ff5733',
+            'orden': 1,
+            'fold_state': 'close'
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['color'], '#FF5733')
+
+    def test_filter_by_project_includes_color(self):
+        """Test filtering by project includes color"""
+        url = f'/api/layer-groups/?project={self.project.id}'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertGreater(len(response.data), 0)
+        self.assertIn('color', response.data[0])
+
+    def test_nested_serialization_includes_color(self):
+        """Test nested serialization in project detail includes color"""
+        url = f'/api/projects/{self.project.id}/'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('layer_groups', response.data)
+        if len(response.data['layer_groups']) > 0:
+            self.assertIn('color', response.data['layer_groups'][0])
+
+    def test_unauthenticated_cannot_create(self):
+        """Test unauthenticated user cannot create"""
+        url = '/api/layer-groups/'
+        data = {
+            'proyecto': self.project.id,
+            'nombre': 'New Group',
+            'color': '#00FF00',
+            'orden': 1,
+            'fold_state': 'close'
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_unauthenticated_can_read(self):
+        """Test unauthenticated user can read"""
+        url = f'/api/layer-groups/{self.group.id}/'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('color', response.data)

--- a/applications/projects/tests/test_models.py
+++ b/applications/projects/tests/test_models.py
@@ -1,0 +1,165 @@
+"""
+Unit tests for LayerGroup color field validation
+"""
+from django.test import TestCase
+from django.core.exceptions import ValidationError
+from applications.projects.models import LayerGroup, Project
+
+
+class LayerGroupColorTests(TestCase):
+    """Test cases for LayerGroup color field"""
+
+    def setUp(self):
+        """Set up test data"""
+        self.project = Project.objects.create(
+            nombre_corto='test',
+            nombre='Test Project',
+            coordenada_central_x=-74.0,
+            coordenada_central_y=4.0
+        )
+
+    def test_valid_6_digit_color(self):
+        """Test valid 6-digit hex color"""
+        group = LayerGroup.objects.create(
+            proyecto=self.project,
+            nombre='Test Group',
+            color='#FF5733'
+        )
+        self.assertEqual(group.color, '#FF5733')
+
+    def test_valid_3_digit_color(self):
+        """Test valid 3-digit hex color"""
+        group = LayerGroup.objects.create(
+            proyecto=self.project,
+            nombre='Test Group',
+            color='#F57'
+        )
+        self.assertEqual(group.color, '#F57')
+
+    def test_default_color(self):
+        """Test default color value"""
+        group = LayerGroup.objects.create(
+            proyecto=self.project,
+            nombre='Test Group'
+        )
+        self.assertEqual(group.color, '#e3e3e3')
+
+    def test_lowercase_hex_color(self):
+        """Test lowercase hex color is accepted"""
+        group = LayerGroup.objects.create(
+            proyecto=self.project,
+            nombre='Test Group',
+            color='#ff5733'
+        )
+        self.assertEqual(group.color, '#ff5733')
+
+    def test_mixed_case_hex_color(self):
+        """Test mixed case hex color is accepted"""
+        group = LayerGroup.objects.create(
+            proyecto=self.project,
+            nombre='Test Group',
+            color='#Ff5733'
+        )
+        self.assertEqual(group.color, '#Ff5733')
+
+    def test_invalid_color_format(self):
+        """Test invalid color format raises validation error"""
+        group = LayerGroup(
+            proyecto=self.project,
+            nombre='Test Group',
+            color='invalid'
+        )
+        with self.assertRaises(ValidationError) as context:
+            group.full_clean()
+        self.assertIn('color', context.exception.message_dict)
+
+    def test_color_without_hash(self):
+        """Test color without # prefix raises validation error"""
+        group = LayerGroup(
+            proyecto=self.project,
+            nombre='Test Group',
+            color='FF5733'
+        )
+        with self.assertRaises(ValidationError) as context:
+            group.full_clean()
+        self.assertIn('color', context.exception.message_dict)
+
+    def test_invalid_hex_characters(self):
+        """Test invalid hex characters raise validation error"""
+        group = LayerGroup(
+            proyecto=self.project,
+            nombre='Test Group',
+            color='#GG5733'
+        )
+        with self.assertRaises(ValidationError) as context:
+            group.full_clean()
+        self.assertIn('color', context.exception.message_dict)
+
+    def test_wrong_length_color(self):
+        """Test wrong length color raises validation error"""
+        # 4 digits (invalid)
+        group = LayerGroup(
+            proyecto=self.project,
+            nombre='Test Group',
+            color='#FF57'
+        )
+        with self.assertRaises(ValidationError) as context:
+            group.full_clean()
+        self.assertIn('color', context.exception.message_dict)
+
+    def test_too_long_color(self):
+        """Test too long color raises validation error"""
+        group = LayerGroup(
+            proyecto=self.project,
+            nombre='Test Group',
+            color='#FF57333'
+        )
+        with self.assertRaises(ValidationError) as context:
+            group.full_clean()
+        self.assertIn('color', context.exception.message_dict)
+
+    def test_empty_color(self):
+        """Test empty color uses default"""
+        group = LayerGroup.objects.create(
+            proyecto=self.project,
+            nombre='Test Group',
+            color=''
+        )
+        # Empty string should use default
+        self.assertEqual(group.color, '')
+
+    def test_color_with_spaces(self):
+        """Test color with spaces raises validation error"""
+        group = LayerGroup(
+            proyecto=self.project,
+            nombre='Test Group',
+            color='# FF5733'
+        )
+        with self.assertRaises(ValidationError) as context:
+            group.full_clean()
+        self.assertIn('color', context.exception.message_dict)
+
+    def test_update_color(self):
+        """Test updating color field"""
+        group = LayerGroup.objects.create(
+            proyecto=self.project,
+            nombre='Test Group',
+            color='#FF5733'
+        )
+        group.color = '#00FF00'
+        group.save()
+        group.refresh_from_db()
+        self.assertEqual(group.color, '#00FF00')
+
+    def test_color_persists_after_save(self):
+        """Test color persists correctly after save"""
+        group = LayerGroup.objects.create(
+            proyecto=self.project,
+            nombre='Test Group',
+            color='#123ABC'
+        )
+        group_id = group.id
+
+        # Retrieve from database
+        retrieved_group = LayerGroup.objects.get(id=group_id)
+        self.assertEqual(retrieved_group.color, '#123ABC')

--- a/applications/projects/views.py
+++ b/applications/projects/views.py
@@ -1,4 +1,4 @@
-from rest_framework import viewsets, status
+from rest_framework import viewsets, status, permissions
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from django.shortcuts import get_object_or_404
@@ -144,12 +144,13 @@ class ProjectViewSet(viewsets.ReadOnlyModelViewSet):
         return Response(serializer.data)
 
 
-class LayerGroupViewSet(viewsets.ReadOnlyModelViewSet):
+class LayerGroupViewSet(viewsets.ModelViewSet):
     """
-    ViewSet for LayerGroup model
+    ViewSet for LayerGroup model with full CRUD operations
     """
     queryset = LayerGroup.objects.all()
     serializer_class = LayerGroupSerializer
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 
     def get_queryset(self):
         """
@@ -160,6 +161,18 @@ class LayerGroupViewSet(viewsets.ReadOnlyModelViewSet):
         if project_id is not None:
             queryset = queryset.filter(proyecto_id=project_id)
         return queryset
+
+    def perform_create(self, serializer):
+        """
+        Custom create with validation
+        """
+        serializer.save()
+
+    def perform_update(self, serializer):
+        """
+        Custom update with validation
+        """
+        serializer.save()
 
 
 class LayerViewSet(viewsets.ReadOnlyModelViewSet):

--- a/applications/projects/views.py
+++ b/applications/projects/views.py
@@ -7,10 +7,10 @@ from django.contrib.admin.views.decorators import staff_member_required
 from django.views.decorators.http import require_http_methods
 from django.views.decorators.csrf import csrf_exempt
 import json
-from .models import Project, LayerGroup, Layer, DefaultLayer
+from .models import Project, LayerGroup, Layer
 from .serializers import (
     ProjectSerializer, ProjectDetailSerializer, LayerGroupSerializer,
-    LayerSerializer, DefaultLayerSerializer
+    LayerSerializer
 )
 
 
@@ -133,15 +133,6 @@ class ProjectViewSet(viewsets.ReadOnlyModelViewSet):
         serializer = LayerSerializer(layers, many=True)
         return Response(serializer.data)
 
-    @action(detail=True, methods=['get'])
-    def default_layers(self, request, pk=None):
-        """
-        Get default layers for a specific project
-        """
-        project = self.get_object()
-        default_layers = project.default_layers.all()
-        serializer = DefaultLayerSerializer(default_layers, many=True)
-        return Response(serializer.data)
 
 
 class LayerGroupViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
- Introduced a custom form for LayerGroup admin to include a color picker for layer group color selection.
- Added a color preview feature in the admin list view to visually represent the selected color.
- Updated LayerGroup model to include a color field with validation for hexadecimal format.
- Modified LayerGroupSerializer to validate and normalize color input.
- Changed LayerGroupViewSet to support full CRUD operations, enhancing the admin interface functionality.
