### PR TITLE
Add compose override for network integration

### DIFF
--- a/docker-compose.override.local.yml
+++ b/docker-compose.override.local.yml
@@ -1,0 +1,10 @@
+version: "3"
+
+services:
+  web:
+    networks:
+    - i2d_visor
+
+networks:
+  i2d_visor:
+    external: true


### PR DESCRIPTION
This will allow Visor I2D Backend service to join a shared Docker network used by other Visor I2D component when running locally

## 🛠️ Changes
> A new docker-compose.override was created to allow the backend to join a shared docker network for local development. This will allow it to communicate with other components of Visor I2D (Database and Geoserver)

## 📝 Associated issues
[LIB-451](https://linear.app/biodev/issue/LIB-451/levantar-visor-i2d-en-maquina-local-y-actualizar-documentacion)

## 🤔 Considerations
To use it, run: docker compose -f docker-compose.yml -f docker-compose.override.local.yml up -d

## ✅ Checks
DB and geoserver can also join the shared docker network during local development.
