### PR TITLE
lserrano/LIB-582: Update scripts to populate layers with correct ids to BioCultural

### DIFF
--- a/docs/add_missing_layers.py
+++ b/docs/add_missing_layers.py
@@ -76,7 +76,7 @@ def main():
         restauracion_group = created_groups['Restauración']
         restauracion_layers = [
             {'geoserver': 'integr_total4326', 'display': 'Integridad', 'store_geoserver': 'restauracion', 'metadata': '55d29ef5-e419-489f-a450-3299e4bcc4d4', 'orden': 1},
-            {'geoserver': 'red_viveros', 'display': 'Red Viveros',  'store_geoserver': 'visor', 'metadata': None, 'orden': 2},
+            {'geoserver': 'red_viveros', 'display': 'Red Viveros',  'store_geoserver': 'visor', 'metadata': '7UAZDX', 'orden': 2},
             {'geoserver': 'scen_mincost_target1', 'display': 'Escenario mínimo costo target 1', 'store_geoserver': 'weplan', 'metadata': '1d6b06b6-8a57-4c87-97ef-e156cb40dc46', 'orden': 3},
             {'geoserver': 'scen_mincost_target2', 'display': 'Escenario mínimo costo target 2', 'store_geoserver': 'weplan', 'metadata': '1d6b06b6-8a57-4c87-97ef-e156cb40dc46', 'orden': 4},
             {'geoserver': 'scen_mincost_target3', 'display': 'Escenario mínimo costo target 3', 'store_geoserver': 'weplan', 'metadata': '1d6b06b6-8a57-4c87-97ef-e156cb40dc46', 'orden': 5},
@@ -104,6 +104,7 @@ def main():
             defaults={
                 'nombre_display': 'Paramos',
                 'store_geoserver': 'gefparamos',
+                'metadata': 'LPM4RE',
                 'estado_inicial': False,
                 'orden': 1
             }
@@ -114,6 +115,7 @@ def main():
             defaults={
                 'nombre_display': 'Municipios',
                 'store_geoserver': 'gefparamos',
+                'metadata': 'LPM4RE',
                 'estado_inicial': False,
                 'orden': 2
             }

--- a/docs/layer_configuration_fixes.md
+++ b/docs/layer_configuration_fixes.md
@@ -87,7 +87,7 @@ SELECT v.nombre_geoserver, v.nombre_display, v.store_geoserver, v.estado_inicial
 FROM (
   VALUES
     ('integr_total4326',     'Integridad',                         'Historicos', false, '55d29ef5-e419-489f-a450-3299e4bcc4d4', 1),
-    ('red_viveros',         'Red Viveros',                        'Historicos', false, NULL,                                      2),
+    ('red_viveros',         'Red Viveros',                        'Historicos', false, '7UAZDX', 2),
     ('scen_mincost_target1','Escenario mínimo costo target 1',    'Historicos', false, '1d6b06b6-8a57-4c87-97ef-e156cb40dc46', 3),
     ('scen_mincost_target2','Escenario mínimo costo target 2',    'Historicos', false, '1d6b06b6-8a57-4c87-97ef-e156cb40dc46', 4),
     ('scen_mincost_target3','Escenario mínimo costo target 3',    'Historicos', false, '1d6b06b6-8a57-4c87-97ef-e156cb40dc46', 5),


### PR DESCRIPTION
## 🛠️ Changes
Se agregan los ids a BioCultural a las capas viveros, paramos y municipios en los scripts de creación de capas. 

## 📝 Associated issues
Part of LIB-582

## 🤔 Considerations
Se debe actualizar la base de datos para agregar los ids de las capas faltantes:
`UPDATE layers SET metadata_id='7UAZDX' WHERE nombre_geoserver='red_viveros';`
`UPDATE layers SET metadata_id='LPM4RE' WHERE nombre_geoserver='paramo' OR nombre_geoserver='municipio';`